### PR TITLE
[WIP] Feature/add merge option to preset

### DIFF
--- a/lib/actionloader.py
+++ b/lib/actionloader.py
@@ -18,7 +18,7 @@ class ActionLoader(object):
     try:
       setting = ActionSetting(raw_obj)
       preset = self.get_action_klass('preset').get_applier(
-        setting.action_name, setting.preset_name, False
+        setting.action_name, setting.preset_name, setting.is_merge_preset
       )
       action_klass = self.get_action_klass(setting.action_name)
       param_obj = ActionParams(

--- a/lib/actions/preset.py
+++ b/lib/actions/preset.py
@@ -20,24 +20,26 @@ class _PresetApplier(object):
     elif self.preset_name not in presets:
       raise Exception("preset '" + self.action_name + "." + self.preset_name + "' is not defined")
 
-    preset_params = dict(presets[self.preset_name])
-    self.apply_params(preset_params, action_params, self.is_merge)
-    return preset_params
+    # preset_params は変更禁止
+    preset_params = presets[self.preset_name]
+    return self.apply_params(preset_params, action_params, self.is_merge)
 
   @staticmethod
   def apply_params(before, after, is_merge):
-    for key, value in after.items():
-      if key not in before or type(before[key]) is not type(value) or not is_merge:
-        # preset に存在しないキー、または型が違う、または上書きモードの場合は上書き
-        before[key] = value
-      else:
+    after = dict(after)
+    for key, value in before.items():
+      if key not in after or type(after[key]) is not type(value):
+        # action 作成時にセットされていないキー、または型が違う、または上書きモードの場合は上書き
+        after[key] = value
+      elif is_merge:
         if isinstance(value, list):
-          before[key].extend(value)
+          after[key] = value + after[key]
         elif isinstance(value, dict):
-          before[key].update(value)
+          after[key].update(value)
         else:
           # 数値・文字列の場合は上書き
-          before[key] = value
+          after[key] = value
+    return after
 
 
 class Preset(BaseAction):

--- a/lib/actions/preset.py
+++ b/lib/actions/preset.py
@@ -28,17 +28,16 @@ class _PresetApplier(object):
   def apply_params(before, after, is_merge):
     after = dict(after)
     for key, value in before.items():
-      if key not in after or type(after[key]) is not type(value):
-        # action 作成時にセットされていないキー、または型が違う、または上書きモードの場合は上書き
+      if key not in after:
+        # action 作成時にセットされていないキーの場合は preset の値をそのまま使う
         after[key] = value
       elif is_merge:
-        if isinstance(value, list):
+        if type(value) is not type(after[key]):
+          raise Exception("merging preset parameter failed: types of '{0}' are different".format(key))
+        elif isinstance(value, list):
           after[key] = value + after[key]
         elif isinstance(value, dict):
           after[key].update(value)
-        else:
-          # 数値・文字列の場合は上書き
-          after[key] = value
     return after
 
 

--- a/lib/actions/preset.py
+++ b/lib/actions/preset.py
@@ -44,10 +44,30 @@ class _PresetApplier(object):
 class Preset(BaseAction):
   """ Preset アクション
 
-  任意のアクションに対する実行時のパラメータプリセットを定義する。アクションに対して多数のパラメータを繰り返し適用する場合、事前にプリセットを定義しておくことでシナリオをシンプルにできる。:ref:`references-actions-const-label` アクションと同様にシナリオ実行単位でグローバルに参照可能。
+  http や ssh 等の任意のアクションに対するパラメータプリセットを定義する。認証等のためにアクション作成時に多数のパラメータを繰り返し適用しなければならない場合、事前にプリセットを定義しておくことでシナリオをシンプルにできる。:ref:`references-actions-const-label` アクションと同様にシナリオ実行単位でグローバルに参照可能。
 
-  定義の上書き
-    すでに定義済みのプリセット名と同じ名前で定義した場合、後から定義したパラメータセットで完全に上書きされる。異なるアクション間で同名のプリセット名を持つことは可能。
+  プリセットの作成
+    プリセットを作成するには「対象アクション」「プリセット名」「パラメータセット」を下記のように指定する必要がある。プリセット名を ``default`` にした場合、対象アクションを実行する際に暗黙的に該当のプリセットパラメータが適用される。
+
+    .. code-block:: yaml
+
+       - action: preset
+         http:                         # 対象アクション
+           assert200:                  # プリセット名
+             url: http://yahoo.co.jp/  # パラメータセット: 対象アクションで使用可能なパラメータを任意の数セットする
+             assert:                   # assert もセットできる
+               - out.status is eq 200
+
+  プリセットの使用
+    上記のプリセットが作成された後、アクションを作成する際にアクション名の後ろに ``<`` とプリセット名を記述することでプリセットパラメータを使用することができる。下記の例では google.com にアクセスした上で、ステータスコードが 200 であることを検証する。プリセットのパラメータと同一のキーをアクション作成時にセットした場合は、アクション側のパラメータで上書きされる。ただし、``<<`` を使ってプリセットを適用した場合でかつパラメータがリストか辞書の場合は、マージされる。
+
+    .. code-block:: yaml
+
+       - action: http.get < assert200
+         url: http://google.com/
+
+  プリセットの上書き
+    すでに作成済みのプリセット名と同じ名前でプリセットを作成した場合、後から作成したパラメータセットで完全に上書きされる。異なるアクションを対象にした同名のプリセットを持つことは可能。
 
   評価のタイミング
     preset アクションで定義したパラメータセットは、preset アクションが実行されたタイミングで評価される。パラメータセットの中で :ref:`references-actions-const-label` 定数や :ref:`references-actions-local-label` 変数の使用、または関数呼び出しを記述していた場合、その時点での値でパラメータセットが確定する。評価を遅延させたい場合は
@@ -68,6 +88,10 @@ class Preset(BaseAction):
        http:
          default:
            url: http://yahoo.co.jp/
+       local:
+         set_list:
+           x:
+             - 100
 
      # default preset の適用
      #   アクションに対して何も渡していないが default プリセットがあるので
@@ -80,10 +104,18 @@ class Preset(BaseAction):
            assert:
              - out.status is 404
 
-     # named preset の適用
+     # named preset の適用（同一キーのパラメータは上書き）
      #   assert を定義していないが status が 404 であることをテストしている
      - action: http.get < assert404
        url: http://yahoo.co.jp/hogehoge
+
+     # named preset の適用（同一キーのパラメータはできるだけマージする）
+     #   action 定義の x と preset の x がマージされる
+     - action: http.get << set_list
+       x:
+         - 200
+       assert:
+         - out.x is eq [100,200]
   """
   _presets = {}
   _default_presets = {}

--- a/lib/actionsetting.py
+++ b/lib/actionsetting.py
@@ -4,7 +4,6 @@ import re
 
 class ActionSetting(object):
 
-  #ACTION_REGEX = re.compile(r'^(?P<actionName>\w+)(?:\.(?P<methodName>\w+))?(?:\s*\<\s*(?P<presetName>\w+))?$')
   ACTION_REGEX = re.compile(r'^(?P<actionName>\w+)(?:\.(?P<methodName>\w+))?(?:\s*(?P<presetMode>\<\<?)\s*(?P<presetName>\w+))?$')
 
   def __init__(self, raw_obj):

--- a/lib/actionsetting.py
+++ b/lib/actionsetting.py
@@ -4,7 +4,8 @@ import re
 
 class ActionSetting(object):
 
-  ACTION_REGEX = re.compile(r'^(?P<actionName>\w+)(?:\.(?P<methodName>\w+))?(?:\s*\<\s*(?P<presetName>\w+))?$')
+  #ACTION_REGEX = re.compile(r'^(?P<actionName>\w+)(?:\.(?P<methodName>\w+))?(?:\s*\<\s*(?P<presetName>\w+))?$')
+  ACTION_REGEX = re.compile(r'^(?P<actionName>\w+)(?:\.(?P<methodName>\w+))?(?:\s*(?P<presetMode>\<\<?)\s*(?P<presetName>\w+))?$')
 
   def __init__(self, raw_obj):
     if 'action' not in raw_obj or not raw_obj['action']:
@@ -13,6 +14,7 @@ class ActionSetting(object):
     match_dict = self._parse_action_id(raw_obj['action'])
     action_name = match_dict['actionName']
     method_name = match_dict['methodName']
+    preset_mode = match_dict['presetMode']
     preset_name = match_dict['presetName']
     line_number = raw_obj['__line__']
 
@@ -26,6 +28,7 @@ class ActionSetting(object):
 
     self.action_name = action_name
     self.method_name = method_name
+    self.is_merge_preset = True if preset_mode == '<<' else False
     self.preset_name = preset_name
     self.line_number = line_number
 

--- a/sample_scenario/presetTest.yml
+++ b/sample_scenario/presetTest.yml
@@ -1,0 +1,38 @@
+- preset テスト
+
+- action: preset
+  local:
+    set_x:
+      x:
+        - 100
+    set_y:
+      y:
+        hoge: 100
+
+# set_x とマージされる（リスト）
+- action: local << set_x
+  x:
+    - 200
+  assert:
+    - out.x is eq [100, 200]
+
+# set_x の内容が新しいパラメータで上書きされる（リスト）
+- action: local < set_x
+  x:
+    - 300
+  assert:
+    - out.x is eq [300]
+
+# set_y とマージされる（辞書）
+- action: local << set_y
+  y:
+    fuga: 200
+  assert:
+    - out.y is eq {"hoge":100,"fuga":200}
+
+# assert200 の内容が新しいパラメータで上書きされる（辞書）
+- action: local < set_y
+  y:
+    fuga: 300
+  assert:
+    - out.y is eq {"fuga":300}

--- a/sample_scenario/presetTest.yml
+++ b/sample_scenario/presetTest.yml
@@ -30,6 +30,12 @@
   assert:
     - out.y is eq {"hoge":100,"fuga":200}
 
+- action: local << set_y
+  y:
+    bar: 200
+  assert:
+    - out.y is eq {"hoge":100,"bar":200}
+
 # assert200 の内容が新しいパラメータで上書きされる（辞書）
 - action: local < set_y
   y:


### PR DESCRIPTION
これまでは preset と同一のキーをパラメータに指定した場合、preset を上書きしていた。
```
- action: http < preset_name
```
"<<" を使うことで、同一キーの場合の挙動を変更することができる（preset と action 定義におけるパラメータ指定の型が同一でかつその型がリストまたは辞書の場合のみ）
```
- action: http << preset_name
```